### PR TITLE
Mark forgetpass as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
This application is no longer maintained

> This repository has been archived by the owner on Aug 18, 2024. It is now read-only. 

Source: https://github.com/alexkdeveloper/forgetpass